### PR TITLE
Markdown blog posts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ add the badge to your github project with the following snippet:
 ```
 [![Unitary Fund](https://img.shields.io/badge/Supported%20By-UNITARY%20FUND-brightgreen.svg?style=for-the-badge)](http://unitary.fund)
 ```
+
+## Writing a blog post
+
+Blog posts are written in markdown and a template for can be found under `posts/markdown/`. and images for the post should be added to `images` at root.
+Make a PR to this site with your new markdown file and the team can review and merge it!
+
+If you want to see how your blog post looks like, you can use pandoc and run the following command in the `posts` folder:
+
+```bash
+pandoc --standalone --template pandoc-template.html ./markdown/your_post.md -o your_post.html
+```
+
+To view the entire site hosted by Python locally, run the following command:
+
+```bash
+python -m http.server 8000 --bind 127.0.0.1
+```

--- a/posts/markdown/post-template.md
+++ b/posts/markdown/post-template.md
@@ -1,0 +1,18 @@
+---
+title: Post Title
+date: Month DD, YYYY
+author: Your Name
+---
+<!--
+Thanks for contributing a blog post to the UF site!
+
+Some quick tips:
+- Use the `title` field to set the title of your post, no first level header needed.
+- Standard markdown formatting is supported (code blocks, links, images, etc.)
+  - Put images for your post in the `images` folder.
+- If you need further custom formatting, direct html will work here as well.
+- 
+
+
+NOTE: If this post needs external attribution, include the line below at the very top.
+> _This blog was originally posted [here](), and is reproduced with the author's permission._ -->

--- a/posts/markdown/ufambassadors.md
+++ b/posts/markdown/ufambassadors.md
@@ -1,0 +1,26 @@
+---
+title: Announcing the Unitary Fund Ambassador Program and introducing our first Ambassadors
+date: October 18, 2021
+author: Unitary Fund Team
+---
+
+Quantum technology is growing rapidly, and finding space where you can grow and succeed is more important than ever. Open source tools and communities are a critical component in enabling the development of cutting edge quantum technologies. However, there is a lack of acknowledgement for the amazing things people are supporting these efforts and projects around the globe. As a non-profit organization supporting the open quantum ecosystem, we want to help change that.
+
+## Unitary Fund Ambassadors program
+
+The Unitary Fund is excited to announce our new Quantum Ambassadors program, a way of recognizing individuals that are directly addressing the challenges of the growing quantum community. Unitary Fund Quantum Ambassadors bring together their peers to learn new skills, develop open source tools, and build the open quantum community all over the world.
+
+Anyone is eligible to become an ambassador, and winners are nominated by the Unitary Fund team on a rolling basis. We expect that ambassadors exemplify Unitary Fund values and conduct themselves with respect whenever they engage with others within and outside the open quantum community.
+
+## Introducing the first Ambassadors 🎉
+
+Picking our first Ambassadors was a hard job, with so many amazing folks contributing to the open quantum ecosystem. Given the competitive field, these individuals are outstanding in how they engage and collaborate with the community, and make their own contributions to OSS projects. So, without further ado, here are our first group of ambassadors!
+
+<ul style="list-style-type: none;">
+    <li class="leading-block">Andre Alves |  <a href="https://github.com/andre-a-alves" target="_blank" >GitHub</a> <a href="https://www.linkedin.com/in/andre-a-alves" target="_blank" >LinkedIn</a></li><br>
+    <li class="leading-block"> Aaron Robertson |  <a href="https://github.com/Aaron-Robertson" target="_blank" >GitHub</a> <a href="https://www.linkedin.com/in/aaron-robertson-0655b811b/" target="_blank" >LinkedIn</a></li><br>
+    <li class="leading-block">Purva Thakre | <a href="https://github.com/purva-thakre" target="_blank" >GitHub</a></li><br>
+    <li class="leading-block">Misty Wahl |  <a href="https://github.com/Misty-W" target="_blank" >GitHub</a> <a href="https://www.linkedin.com/in/misty-wahl" target="_blank" >LinkedIn</a></li><br>
+</ul>
+
+We will be hosting blog posts from all the Ambassadors in the coming weeks so stay tuned right here! Join our [newsletter](https://mailchi.mp/46a677be77cd/uf) to get updates about this blog in your inbox, follow us on [Twitter](https://twitter.com/unitaryfund), or join our [Discord](http://discord.unitary.fund) to hang out with the open quantum community 💛🌴


### PR DESCRIPTION
Removed the scheduled post action from #145 that required reverting in #147. That action was not fully configured yet, and will need a bit more work/testing. The markdown blogging instructions are much more time sensitive, so this PR adds the md folder/sources back and the instructions on how to use them