### PR TITLE
Add qolour.io website link to Qubi grant page

### DIFF
--- a/src/content/grant/2025_Qubi.md
+++ b/src/content/grant/2025_Qubi.md
@@ -7,4 +7,4 @@ country: US
 tags:
   - education
 ---
-To **Sohum Thakkar, Andrew Chen, and Roger Mao** to develop Qubi, an interactive device that the team hopes will be used by quantum enthusiasts as a teaching tool and by quantum newbies looking to learn quantum in an intuitive way.
+To **Sohum Thakkar, Andrew Chen, and Roger Mao** to develop Qubi, an interactive device that the team hopes will be used by quantum enthusiasts as a teaching tool and by quantum newbies looking to learn quantum in an intuitive way. Learn more at [qolour.io](https://www.qolour.io) and watch a demo on [YouTube](https://www.youtube.com/watch?v=Sn-tyARdG-g).


### PR DESCRIPTION
Hi! Adding a link to the Qubi project website and YouTube demo to the 2025 Qubi grant page, as discussed with Veena.

- Website: https://www.qolour.io
- YouTube demo: https://www.youtube.com/watch?v=Sn-tyARdG-g