### PR TITLE
Fix GitHub Pages deploy runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   # Using a different branch name? Replace `main` with your branch's name
   push:
     branches: [main]
+  pull_request:
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
@@ -17,19 +18,20 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: github-pages
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install, build, and upload your site
-        uses: withastro/action@v2
+        uses: withastro/action@v6
         with:
-          package-manager: pnpm@latest
+          node-version: 22
+          package-manager: pnpm@10.33.2
         env:
           PUBLIC_CLOUDINARY_CLOUD_NAME: ${{ vars.PUBLIC_CLOUDINARY_CLOUD_NAME }}
           PUBLIC_CLOUDINARY_UPLOAD_PRESET: ${{ vars.PUBLIC_CLOUDINARY_UPLOAD_PRESET }}
 
   deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -38,4 +40,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "unitary-fund",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
## Summary
- upgrade the Astro Pages deploy action from v2 to v6
- build with Node 22 to match the repo engine
- pin pnpm to 10.33.2 instead of pnpm@latest
- update checkout/deploy-pages actions to current major versions
- run the build job on PRs, while keeping deploy limited to main

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "workflow yaml ok"'`
- `CI=true pnpm install --frozen-lockfile`
- `pnpm run build`

Fixes #993